### PR TITLE
zfssa-7 - proliferate logging to identify credential rotation and ena…

### DIFF
--- a/pkg/service/controller.go
+++ b/pkg/service/controller.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2022, Oracle.
  * Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
  */
 
@@ -44,7 +44,7 @@ func (zd *ZFSSADriver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRe
 	if err != nil {
 		return nil, status.Error(codes.Unauthenticated, "Invalid credentials")
 	}
-	token := zfssarest.LookUpToken(user, password)
+	token := zfssarest.LookUpToken(ctx, user, password)
 
 	// Validate the parameters
 	if err := validateCreateVolumeReq(ctx, token, req); err != nil {
@@ -181,7 +181,7 @@ func (zd *ZFSSADriver) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeRe
 	if err != nil {
 		return nil, status.Error(codes.Unauthenticated, "Invalid credentials")
 	}
-	token := zfssarest.LookUpToken(user, password)
+	token := zfssarest.LookUpToken(ctx, user, password)
 
 	volumeID := req.GetVolumeId()
 	if len(volumeID) == 0 {
@@ -249,7 +249,7 @@ func (zd *ZFSSADriver) ControllerPublishVolume(ctx context.Context, req *csi.Con
 	if err != nil {
 		return nil, status.Error(codes.Unauthenticated, "Invalid credentials")
 	}
-	token := zfssarest.LookUpToken(user, password)
+	token := zfssarest.LookUpToken(ctx, user, password)
 
 	zvol, err := zd.lookupVolume(ctx, token, volumeID)
 	if err != nil {
@@ -280,7 +280,7 @@ func (zd *ZFSSADriver) ControllerUnpublishVolume(ctx context.Context, req *csi.C
 	if err != nil {
 		return nil, status.Error(codes.Unauthenticated, "Invalid credentials")
 	}
-	token := zfssarest.LookUpToken(user, password)
+	token := zfssarest.LookUpToken(ctx, user, password)
 
 	zvol, err := zd.lookupVolume(ctx, token, volumeID)
 	if err != nil {
@@ -317,7 +317,7 @@ func (zd *ZFSSADriver) ValidateVolumeCapabilities(ctx context.Context, req *csi.
 	if err != nil {
 		return nil, status.Error(codes.Unauthenticated, "Invalid credentials")
 	}
-	token := zfssarest.LookUpToken(user, password)
+	token := zfssarest.LookUpToken(ctx, user, password)
 
 	zvol, err := zd.lookupVolume(ctx, token, volumeID)
 	if err != nil {
@@ -409,7 +409,7 @@ func (zd *ZFSSADriver) GetCapacity(ctx context.Context, req *csi.GetCapacityRequ
 	if err != nil {
 		return nil, status.Error(codes.Unauthenticated, "Invalid credentials")
 	}
-	token := zfssarest.LookUpToken(user, password)
+	token := zfssarest.LookUpToken(ctx, user, password)
 
 	parameters := req.GetParameters()
 	projectName, ok := parameters["project"]
@@ -487,7 +487,7 @@ func (zd *ZFSSADriver) CreateSnapshot(ctx context.Context, req *csi.CreateSnapsh
 	if err != nil {
 		return nil, status.Error(codes.Unauthenticated, "Invalid credentials")
 	}
-	token := zfssarest.LookUpToken(user, password)
+	token := zfssarest.LookUpToken(ctx, user, password)
 
 	zsnap, err := zd.newSnapshot(ctx, token, snapName, sourceId)
 	if err != nil {
@@ -514,7 +514,7 @@ func (zd *ZFSSADriver) DeleteSnapshot(ctx context.Context, req *csi.DeleteSnapsh
 	if err != nil {
 		return nil, status.Error(codes.Unauthenticated, "Invalid credentials")
 	}
-	token := zfssarest.LookUpToken(user, password)
+	token := zfssarest.LookUpToken(ctx, user, password)
 
 	// Get exclusive access to the snapshot.
 	zsnap, err := zd.lookupSnapshot(ctx, token, req.SnapshotId)
@@ -566,7 +566,7 @@ func (zd *ZFSSADriver) ListSnapshots(ctx context.Context, req *csi.ListSnapshots
 	if err != nil {
 		return nil, status.Error(codes.Unauthenticated, "Invalid credentials")
 	}
-	token := zfssarest.LookUpToken(user, password)
+	token := zfssarest.LookUpToken(ctx, user, password)
 
 	var entries []*csi.ListSnapshotsResponse_Entry
 
@@ -646,7 +646,7 @@ func (zd *ZFSSADriver) ControllerExpandVolume(ctx context.Context, req *csi.Cont
 	if err != nil {
 		return nil, status.Error(codes.Unauthenticated, "Invalid credentials")
 	}
-	token := zfssarest.LookUpToken(user, password)
+	token := zfssarest.LookUpToken(ctx, user, password)
 
 	zvol, err := zd.lookupVolume(ctx, token, volumeID)
 	if err != nil {

--- a/pkg/service/identity.go
+++ b/pkg/service/identity.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2022, Oracle.
  * Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
  */
 
@@ -69,7 +69,7 @@ func (zd *ZFSSADriver) Probe(ctx context.Context, req *csi.ProbeRequest) (
 	if err != nil {
 		return nil, grpcStatus.Error(codes.Unauthenticated, "Invalid credentials")
 	}
-	token := zfssarest.LookUpToken(user, password)
+	token := zfssarest.LookUpToken(ctx, user, password)
 	_, err = zfssarest.GetServices(ctx, token)
 	if err != nil {
 		return &csi.ProbeResponse{

--- a/pkg/service/node.go
+++ b/pkg/service/node.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2022, Oracle.
  * Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
  */
 
@@ -165,7 +165,7 @@ func (zd *ZFSSADriver) NodePublishVolume(ctx context.Context, req *csi.NodePubli
 	if err != nil {
 		return nil, status.Error(codes.Unauthenticated, "Invalid credentials")
 	}
-	token := zfssarest.LookUpToken(user, password)
+	token := zfssarest.LookUpToken(ctx, user, password)
 
 	var mountOptions []string
 	if req.GetReadonly() {
@@ -217,7 +217,7 @@ func (zd *ZFSSADriver) NodeUnpublishVolume(ctx context.Context, req *csi.NodeUnp
 	if err != nil {
 		return nil, status.Error(codes.Unauthenticated, "Invalid credentials")
 	}
-	token := zfssarest.LookUpToken(user, password)
+	token := zfssarest.LookUpToken(ctx, user, password)
 	if zVolumeId.IsBlock() {
 		return zd.nodeUnpublishBlockVolume(ctx, token, req, zVolumeId)
 	} else {

--- a/pkg/service/volumes.go
+++ b/pkg/service/volumes.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2022, Oracle.
  * Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
  */
 
@@ -435,7 +435,7 @@ func (zd *ZFSSADriver) updateFilesystemList(ctx context.Context, out chan<- erro
 	if err != nil {
 		out <- err
 	}
-	token := zfssarest.LookUpToken(user, password)
+	token := zfssarest.LookUpToken(ctx, user, password)
 	fsList, err := zfssarest.GetFilesystems(ctx, token, "", "")
 	if err != nil {
 		utils.GetLogCTRL(ctx, 2).Println("zd.updateFilesystemList failed", "error", err.Error())
@@ -461,7 +461,7 @@ func (zd *ZFSSADriver) updateLunList(ctx context.Context, out chan<- error) {
 	if err != nil {
 		out <- err
 	}
-	token := zfssarest.LookUpToken(user, password)
+	token := zfssarest.LookUpToken(ctx, user, password)
 
 	lunList, err := zfssarest.GetLuns(ctx, token, "", "")
 	if err != nil {
@@ -520,7 +520,7 @@ func (zd *ZFSSADriver) updateSnapshotList(ctx context.Context) error {
 		return err
 	}
 
-	token := zfssarest.LookUpToken(user, password)
+	token := zfssarest.LookUpToken(ctx, user, password)
 	snapList, err := zfssarest.GetSnapshots(ctx, token, "")
 	if err != nil {
 		utils.GetLogCTRL(ctx, 2).Println("zd.updateSnapshotList failed", "error", err.Error())


### PR DESCRIPTION
Addresses locations that use sidecars to maintain secret credential locations that can rotate credentials.

This PR also proliferates logging to make it easier to track down when credentials rotated and new sessions had to be generated.

Testing included
- destroy rest tokens on target appliance and ensure they are regenerated
- rotate credentials on appliance and in sidecar to ensure new operations work
- incorrectly rotate credentials without appliance being updated, destroy rest tokens on the appliance to force re-login. New operations retry until appliance is updated or credentials are rotated back to working

