### PR TITLE
Allow to provide config values via mounted file

### DIFF
--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2023, Oracle and/or its affiliates.
  * Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
  */
 
@@ -31,6 +31,7 @@ const (
 	DefaultLogLevel = "3"
 	DefaultCertPath = "/mnt/certs/zfssa.crt"
 	DefaultCredPath = "/mnt/zfssa/zfssa.yaml"
+	DefaultConfigPath = "/mnt/config/config.yaml"
 )
 
 type ZFSSADriver struct {
@@ -174,7 +175,8 @@ func getConfig(zd *ZFSSADriver) error {
 		return errors.New(fmt.Sprintf("Cannot get ZFSSA username: %s", err))
 	}
 
-	appliance := getEnvFallback("ZFSSA_TARGET", "")
+	zfssaHost, _ := utils.GetValueFromYAML(DefaultConfigPath,"ZFSSA_TARGET")
+	appliance := getEnvFallback("ZFSSA_TARGET", zfssaHost)
 	zd.config.Appliance = strings.TrimSpace(appliance)
 	if zd.config.Appliance == "not-set" {
 		return errors.New("appliance name required")

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -175,6 +175,7 @@ func getConfig(zd *ZFSSADriver) error {
 		return errors.New(fmt.Sprintf("Cannot get ZFSSA username: %s", err))
 	}
 
+    // Get ZFSSA_TARGET from the mounted config file if available
 	zfssaHost, _ := utils.GetValueFromYAML(DefaultConfigPath,"ZFSSA_TARGET")
 	appliance := getEnvFallback("ZFSSA_TARGET", zfssaHost)
 	zd.config.Appliance = strings.TrimSpace(appliance)

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -175,7 +175,7 @@ func getConfig(zd *ZFSSADriver) error {
 		return errors.New(fmt.Sprintf("Cannot get ZFSSA username: %s", err))
 	}
 
-   // Get ZFSSA_TARGET from the mounted config file if available
+        // Get ZFSSA_TARGET from the mounted config file if available
 	zfssaHost, _ := utils.GetValueFromYAML(DefaultConfigPath,"ZFSSA_TARGET")
 	appliance := getEnvFallback("ZFSSA_TARGET", zfssaHost)
 	zd.config.Appliance = strings.TrimSpace(appliance)

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -175,7 +175,7 @@ func getConfig(zd *ZFSSADriver) error {
 		return errors.New(fmt.Sprintf("Cannot get ZFSSA username: %s", err))
 	}
 
-    // Get ZFSSA_TARGET from the mounted config file if available
+   // Get ZFSSA_TARGET from the mounted config file if available
 	zfssaHost, _ := utils.GetValueFromYAML(DefaultConfigPath,"ZFSSA_TARGET")
 	appliance := getEnvFallback("ZFSSA_TARGET", zfssaHost)
 	zd.config.Appliance = strings.TrimSpace(appliance)

--- a/pkg/utils/parser_utils.go
+++ b/pkg/utils/parser_utils.go
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates.
+ * Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+ */
+
+package utils
+
+import (
+	"io/ioutil"
+	"gopkg.in/yaml.v2"
+	"errors"
+	"fmt"
+)
+
+func GetValueFromYAML(yamlFilePath string, key string) (string, error) {
+	yamlData, err := ioutil.ReadFile(yamlFilePath)
+	if err != nil {
+		return "", errors.New(fmt.Sprintf("the file <%s> could not be read from: <%s>",
+			yamlFilePath, err))
+	}
+
+	// Unmarshal YAML into a map[string]interface{}
+	yamlMap := make(map[string]interface{})
+	err = yaml.Unmarshal(yamlData, &yamlMap)
+	if err != nil {
+		return "", errors.New(fmt.Sprintf("the file <%s> could not be parsed: <%s>",
+			yamlFilePath, err))
+	}
+
+	// Get value from map using key
+	value, ok := yamlMap[key]
+	if !ok {
+		return "", errors.New(fmt.Sprintf("key: <%s> could not be retrieved from <%s> : <%s>",
+		     key, yamlFilePath, err))
+	}
+	// Convert value to string and return
+	return fmt.Sprintf("%v", value), nil
+
+}


### PR DESCRIPTION
Add ability to provide config values like ZFSSA_TARGET via a mounted file.

If ZFSSA_TARGET is not provided via environment variable , the code will default to the value found in /mnt/config/config.yaml file else will be empty.